### PR TITLE
Add Ruby 2.3, 2.4 to Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: ruby
+before_install:
+  # jruby-head does not have bundler.
+  - which bundle || gem install bundler
 script: spec/run
 rvm:
   - 1.8.7
@@ -7,6 +10,8 @@ rvm:
   - 2.0.0
   - 2.1
   - 2.2
+  - 2.3.3
+  - 2.4.0
   - ruby-head
   - ree
   - jruby-18mode
@@ -17,4 +22,6 @@ matrix:
   include:
     - rvm: jruby
       env: JRUBY_OPTS='--2.0'
+  allow_failures:
+    - rvm: rbx
   fast_finish: true

--- a/spec/run
+++ b/spec/run
@@ -34,7 +34,7 @@ get_gem "rspec-core"         "https://rubygems.org/downloads/rspec-core-3.2.1.ge
 get_gem "rspec-support"      "https://rubygems.org/downloads/rspec-support-3.2.2.gem" &&
 get_gem "rspec-expectations" "https://rubygems.org/downloads/rspec-expectations-3.2.0.gem" &&
 get_gem "rspec-mocks"        "https://rubygems.org/downloads/rspec-mocks-3.2.1.gem" &&
-get_gem "diff-lcs"           "https://rubygems.org/downloads/diff-lcs-1.2.5.gem" || exit 1
+get_gem "diff-lcs"           "https://rubygems.org/downloads/diff-lcs-1.3.gem" || exit 1
 
 
 # run specs


### PR DESCRIPTION
I added Ruby 2.3 and 2.4 to Travis CI.

I added not "2.4" but "2.4.0".
Because last month I tried "2.4" on Travis, it was not available.
I tried to find a official document about supported version strings.
But I could not find it.

I updated "diff-lcs" version to "1.3", because I know it is Ruby 2.4.0 compatibility.

